### PR TITLE
Replace np.bool with bool

### DIFF
--- a/maximask_and_maxitrack/utils.py
+++ b/maximask_and_maxitrack/utils.py
@@ -81,7 +81,7 @@ def read_config_file(file_path, nb_classes, log, to_float=False):
     if to_float:
         return np.array(config_params, dtype=np.float32)
     else:
-        return np.array(config_params, dtype=np.bool)
+        return np.array(config_params, dtype=bool)
 
 
 def get_file_list(im_path):


### PR DESCRIPTION
np.bool was deprecated as of NumPy 1.20 (see https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and the deprecation has expired in NumPy 1.24 (https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations). To fix, I replaced 'np.bool' with the identical name 'bool'